### PR TITLE
Add Random Forest model training block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile phasma")
 endif()
 
+
 ########################################################################
 # Find OpenCV
 ########################################################################
@@ -119,7 +120,7 @@ find_package(Doxygen)
 # components required to the list of GR_REQUIRED_COMPONENTS (in all
 # caps such as FILTER or FFT) and change the version to the minimum
 # API compatible version required.
-set(GR_REQUIRED_COMPONENTS RUNTIME)
+set(GR_REQUIRED_COMPONENTS RUNTIME FFT)
 find_package(Gnuradio "3.7.2" REQUIRED)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
@@ -153,6 +154,7 @@ link_directories(
     ${Boost_LIBRARY_DIRS}
     ${CPPUNIT_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
+    ${GNURADIO_FFT_LIBRARY_DIRS}
 )
 
 # Set component parameters

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -18,5 +18,5 @@
 # Boston, MA 02110-1301, USA.
 
 install(FILES
-    DESTINATION share/gnuradio/grc/blocks
+    phasma_rforest_model.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/phasma_rforest_model.xml
+++ b/grc/phasma_rforest_model.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0"?>
+<block>
+	<name>rforest_model</name>
+	<key>phasma_rforest_model</key>
+	<category>[phasma]</category>
+	<import>import phasma</import>
+	<make>phasma.rforest_model($npredictors,
+		$nobservations,
+		$ninport,
+		$max_depth,
+		$min_sample_count,
+		$regression_accu,
+		$use_surrogates,
+		$max_categories,
+		$calc_var_importance,
+		$active_var_count,
+		$max_iter,
+		$filename)
+	</make>
+
+
+	<param>
+		<name>Predictors number</name>
+		<key>npredictors</key>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Dataset observations</name>
+		<key>nobservations</key>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Input ports number</name>
+		<key>ninport</key>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Max depth</name>
+		<key>max_depth</key>
+		<value>10</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Min sample count</name>
+		<key>min_sample_count</key>
+		<value>2</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Regression accuracy</name>
+		<key>regression_accu</key>
+		<value>0</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Use surrogates</name>
+		<key>use_surrogates</key>
+		<value>False</value>
+		<type>bool</type>
+		<option>
+			<name>Off</name>
+			<key>False</key>
+		</option>
+		<option>
+			<name>On</name>
+			<key>True</key>
+		</option>
+	</param>
+
+	<param>
+		<name>Max categories</name>
+		<key>max_categories</key>
+		<value>16</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Calculate variable importance</name>
+		<key>calc_var_importance</key>
+		<value>True</value>
+		<type>bool</type>
+		<option>
+			<name>Off</name>
+			<key>False</key>
+		</option>
+		<option>
+			<name>On</name>
+			<key>True</key>
+		</option>
+	</param>
+
+	<param>
+		<name>Active variable count</name>
+		<key>active_var_count</key>
+		<value>0</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>Max iterations</name>
+		<key>max_iter</key>
+		<value>100</value>
+		<type>int</type>
+	</param>
+
+	<param>
+		<name>File destination</name>
+		<key>filename</key>
+		<type>file_save</type>
+	</param>
+
+	<sink>
+		<name>in</name>
+		<type>complex</type>
+		<nports>$ninport</nports>
+	</sink>
+
+</block>

--- a/include/phasma/CMakeLists.txt
+++ b/include/phasma/CMakeLists.txt
@@ -22,5 +22,6 @@
 ########################################################################
 install(FILES
     api.h
-    DESTINATION include/phasma
+    log.h
+    rforest_model.h DESTINATION include/phasma
 )

--- a/include/phasma/log.h
+++ b/include/phasma/log.h
@@ -1,0 +1,54 @@
+/*
+ * log.h
+ *
+ *  Created on: Sep 5, 2016
+ *      Author: ctriant
+ */
+
+#ifndef INCLUDE_PHASMA_LOG_H_
+#define INCLUDE_PHASMA_LOG_H_
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/syscall.h>
+
+#define PHASMA_MESSAGES 1
+#define PHASMA_DEBUG_MESSAGES 0
+
+#if PHASMA_MESSAGES
+#define PHASMA_LOG_CLASS_INFO(CLASS_DEBUG_ENABLE, M, ...) 				\
+	do { 										\
+		if(CLASS_DEBUG_ENABLE) { 						\
+				fprintf(stderr, "[INFO]: " M " \n", ##__VA_ARGS__); 	\
+		}									\
+	} while(0)
+
+#else
+#define PHASMA_LOG_CLASS_INFO(CLASS, M, ...)
+#endif
+
+#if PHASMA_MESSAGES
+#define PHASMA_LOG_INFO(M, ...) 							\
+		fprintf(stderr, "[INFO]: " M " \n", ##__VA_ARGS__)
+
+#else
+#define PHASMA_LOG_INFO(M, ...)
+#endif
+
+#define PHASMA_ERROR(M, ...) 							\
+	fprintf(stderr, "[ERROR] %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#define PHASMA_WARN(M, ...) 								\
+	fprintf(stderr, "[WARNING] %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#if PHASMA_DEBUG_MESSAGES
+#define PHASMA_DEBUG(M, ...) 							\
+	fprintf(stderr, "[DEBUG]: " M "\n", ##__VA_ARGS__)
+#else
+#define PHASMA_DEBUG(M, ...)
+#endif
+
+
+
+#endif /* INCLUDE_PHASMA_LOG_H_ */

--- a/include/phasma/rforest_model.h
+++ b/include/phasma/rforest_model.h
@@ -1,0 +1,63 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_PHASMA_RFOREST_MODEL_H
+#define INCLUDED_PHASMA_RFOREST_MODEL_H
+
+#include <phasma/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr
+{
+  namespace phasma
+  {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup phasma
+     *
+     */
+    class PHASMA_API rforest_model : virtual public gr::sync_block
+    {
+    public:
+      typedef boost::shared_ptr<rforest_model> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of phasma::rforest_model.
+       *
+       * To avoid accidental use of raw pointers, phasma::rforest_model's
+       * constructor is in a private implementation
+       * class. phasma::rforest_model::make is the public interface for
+       * creating new instances.
+       */
+      static sptr
+      make (const size_t npredictors, const size_t nobservations,
+	    const size_t ninport, const size_t max_depth, const size_t min_sample_count,
+	    const size_t regression_accu, const uint8_t use_surrogates,
+	    const size_t max_categories, const uint8_t calc_var_importance,
+	    const size_t active_var_count, const size_t max_iter,
+	    const std::string filename);
+    };
+
+  } // namespace phasma
+} // namespace gr
+
+#endif /* INCLUDED_PHASMA_RFOREST_MODEL_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,25 +22,31 @@
 ########################################################################
 include(GrPlatform) #define LIB_SUFFIX
 
-include_directories(${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIR}
+                    ${ARMADILLO_INCLUDE_DIRS})
+                    
 link_directories(${Boost_LIBRARY_DIRS})
 
-include_directories(${ARMADILLO_INCLUDE_DIRS})
-
 list(APPEND phasma_sources
+    rforest_model_impl.cc
 )
 
 set(phasma_sources "${phasma_sources}" PARENT_SCOPE)
 if(NOT phasma_sources)
 	MESSAGE(STATUS "No C++ sources... skipping lib/")
 	return()
-endif(NOT phasma_sources)
+endif(NOT phasma_sources)                                         
+
+list(APPEND phasma_libs ${Boost_LIBRARIES} 
+                            ${OpenCV_LIBS}
+                            ${ARMADILLO_LIBRARIES}
+                            ${GNURADIO_ALL_LIBRARIES}
+)
 
 add_library(gnuradio-phasma SHARED ${phasma_sources})
-target_link_libraries(gnuradio-phasma ${Boost_LIBRARIES} 
-                                      ${OpenCV_LIBS}
-                                      ${ARMADILLO_LIBRARIES}
-                                      ${GNURADIO_ALL_LIBRARIES})
+
+target_link_libraries(gnuradio-phasma ${phasma_libs})
+                       
 set_target_properties(gnuradio-phasma PROPERTIES DEFINE_SYMBOL "gnuradio_phasma_EXPORTS")
 
 if(APPLE)
@@ -76,6 +82,7 @@ target_link_libraries(
   ${Boost_LIBRARIES}
   ${ARMADILLO_LIBRARIES}
   ${CPPUNIT_LIBRARIES}
+  ${GNURADIO_FFT_LIBRARIES}
   gnuradio-phasma
 )
 

--- a/lib/rforest_engine_impl.cc
+++ b/lib/rforest_engine_impl.cc
@@ -1,0 +1,70 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "rforest_engine_impl.h"
+
+namespace gr {
+  namespace phasma {
+
+    rforest_engine::sptr
+    rforest_engine::make()
+    {
+      return gnuradio::get_initial_sptr
+        (new rforest_engine_impl());
+    }
+
+    /*
+     * The private constructor
+     */
+    rforest_engine_impl::rforest_engine_impl()
+      : gr::sync_block("rforest_engine",
+              gr::io_signature::make(<+MIN_IN+>, <+MAX_IN+>, sizeof(<+ITYPE+>)),
+              gr::io_signature::make(<+MIN_OUT+>, <+MAX_OUT+>, sizeof(<+OTYPE+>)))
+    {}
+
+    /*
+     * Our virtual destructor.
+     */
+    rforest_engine_impl::~rforest_engine_impl()
+    {
+    }
+
+    int
+    rforest_engine_impl::work(int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items)
+    {
+      const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+      <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+
+      // Do <+signal processing+>
+
+      // Tell runtime system how many output items we produced.
+      return noutput_items;
+    }
+
+  } /* namespace phasma */
+} /* namespace gr */
+

--- a/lib/rforest_engine_impl.h
+++ b/lib/rforest_engine_impl.h
@@ -1,0 +1,48 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_PHASMA_RFOREST_ENGINE_IMPL_H
+#define INCLUDED_PHASMA_RFOREST_ENGINE_IMPL_H
+
+#include <phasma/rforest_engine.h>
+
+namespace gr {
+  namespace phasma {
+
+    class rforest_engine_impl : public rforest_engine
+    {
+     private:
+      // Nothing to declare in this block.
+
+     public:
+      rforest_engine_impl();
+      ~rforest_engine_impl();
+
+      // Where all the action really happens
+      int work(int noutput_items,
+         gr_vector_const_void_star &input_items,
+         gr_vector_void_star &output_items);
+    };
+
+  } // namespace phasma
+} // namespace gr
+
+#endif /* INCLUDED_PHASMA_RFOREST_ENGINE_IMPL_H */
+

--- a/lib/rforest_model_impl.cc
+++ b/lib/rforest_model_impl.cc
@@ -1,0 +1,184 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <volk/volk.h>
+#include <phasma/log.h>
+#include "rforest_model_impl.h"
+
+namespace gr
+{
+  namespace phasma
+  {
+
+    rforest_model::sptr
+    rforest_model::make (const size_t npredictors, const size_t nobservations,
+			 size_t ninport, const size_t max_depth,
+			 const size_t min_sample_count,
+			 const size_t regression_accu,
+			 const uint8_t use_surrogates,
+			 const size_t max_categories,
+			 const uint8_t calc_var_importance,
+			 const size_t active_var_count, const size_t max_iter,
+			 const std::string filename)
+    {
+      return gnuradio::get_initial_sptr(
+	  new rforest_model_impl(npredictors, nobservations, ninport, max_depth,
+				 min_sample_count, regression_accu,
+				 use_surrogates, max_categories,
+				 calc_var_importance, active_var_count,
+				 max_iter, filename));
+    }
+
+    /*
+     * The private constructor
+     */
+    rforest_model_impl::rforest_model_impl (const size_t npredictors,
+					    const size_t nobservations,
+					    const size_t ninport,
+					    const size_t max_depth,
+					    const size_t min_sample_count,
+					    const size_t regression_accu,
+					    const uint8_t use_surrogates,
+					    const size_t max_categories,
+					    const uint8_t calc_var_importance,
+					    const size_t active_var_count,
+					    const size_t max_iter,
+					    const std::string filename) :
+	    gr::sync_block(
+		"rforest_model",
+		gr::io_signature::make(1, ninport, sizeof(gr_complex)),
+		gr::io_signature::make(0, 0, 0)),
+	    d_npredictors(npredictors * 2), // if complex multiply by 2 for I/Q predictors
+	    d_nobservations(nobservations),
+	    d_remaining(nobservations),
+	    d_ninport(ninport),
+	    d_max_depth(max_depth),
+	    d_min_sample_count(min_sample_count),
+	    d_regression_accu(regression_accu),
+	    d_use_surrogates(use_surrogates),
+	    d_max_categories(max_categories),
+	    d_calc_var_importance(calc_var_importance),
+	    d_active_var_count(active_var_count),
+	    d_max_iter(max_iter),
+	    d_filename(filename)
+    {
+      set_output_multiple(100 * d_npredictors);
+      d_input = (gr_complex*) malloc(d_npredictors * sizeof(gr_complex));
+      d_rfmodel = cv::ml::RTrees::create();
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    rforest_model_impl::~rforest_model_impl ()
+    {
+
+    }
+
+    static void
+    train_and_print_errs (cv::Ptr<cv::ml::StatModel> model,
+			  const cv::Ptr<cv::ml::TrainData>& data)
+    {
+      bool ok = model->train(data);
+      if (!ok) {
+	PHASMA_ERROR("Training failed\n");
+      }
+      else {
+	PHASMA_LOG_INFO("Train error: %f\n",
+	    model->calcError(data, false, cv::noArray()));PHASMA_LOG_INFO("Test error: %f\n", model->calcError(data, true, cv::noArray()));
+      }
+    }
+
+    int
+    rforest_model_impl::work (int noutput_items,
+			      gr_vector_const_void_star &input_items,
+			      gr_vector_void_star &output_items)
+    {
+      const gr_complex *in;
+      size_t available_observations = noutput_items / d_npredictors;
+
+      if (d_nobservations % d_ninport) {
+	PHASMA_WARN(
+	    "Number of requested dataset observation should be multiple of number of inputs.");
+      }
+
+      PHASMA_DEBUG("Available samples: %d\n",noutput_items);PHASMA_DEBUG("Available Observations: %d\n",available_observations);PHASMA_DEBUG("Requested Observations: %d\n",d_nobservations);
+
+      for (int i = 0; i < available_observations; i++) {
+	for (int n = 0; n < d_ninport; n++) {
+
+	  in = (const gr_complex*) input_items[n];
+
+	  memcpy(d_input, &in[i * d_npredictors],
+		 d_npredictors * sizeof(gr_complex));
+
+	  /* Insert new dataset row */
+	  /* TODO: Handle complex */
+	  if (d_predictors.empty() && d_labels.empty()) {
+	    d_predictors = cv::Mat(1, d_npredictors, CV_32F, d_input);
+	    d_labels = cv::Mat(1, 1, CV_32F, n);
+	  }
+	  else {
+	    cv::vconcat(cv::Mat(1, d_npredictors, CV_32F, d_input),
+			d_predictors, d_predictors);
+	    cv::vconcat(cv::Mat(1, 1, CV_32F, n), d_labels, d_labels);
+	  }
+	  d_remaining--;
+
+	  if (d_remaining == 0) {
+	    // TODO: Train model
+	    PHASMA_LOG_INFO("\n\n====== Dataset creation =====\n");
+	    d_train_data = cv::ml::TrainData::create(d_predictors,
+						     cv::ml::ROW_SAMPLE,
+						     d_labels);
+	    d_train_data->setTrainTestSplitRatio(0.85);
+
+	    PHASMA_LOG_INFO("Test/Train: %d/%d\n",d_train_data->getNTestSamples(),d_train_data->getNTrainSamples());
+
+	    PHASMA_LOG_INFO("====== Random Forest training =====\n");
+	    d_rfmodel->setMaxDepth(d_max_depth);
+	    d_rfmodel->setMinSampleCount(d_min_sample_count);
+	    d_rfmodel->setRegressionAccuracy(d_regression_accu);
+	    d_rfmodel->setUseSurrogates(d_use_surrogates);
+	    d_rfmodel->setMaxCategories(d_max_categories);
+	    d_rfmodel->setPriors(cv::Mat());
+	    d_rfmodel->setCalculateVarImportance(d_calc_var_importance);
+	    d_rfmodel->setActiveVarCount(d_active_var_count);
+	    d_rfmodel->setTermCriteria(
+		cv::TermCriteria(cv::TermCriteria::MAX_ITER, d_max_iter, 0));
+	    d_train_data->shuffleTrainTest();
+	    train_and_print_errs(d_rfmodel, d_train_data);
+	    d_rfmodel->save(d_filename);
+	    PHASMA_LOG_INFO("====== Model exported as xml =====\n");
+	    return WORK_DONE;
+	  }
+	}
+      }
+      return noutput_items;
+    }
+
+  } /* namespace phasma */
+} /* namespace gr */
+

--- a/lib/rforest_model_impl.h
+++ b/lib/rforest_model_impl.h
@@ -1,0 +1,93 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_PHASMA_RFOREST_MODEL_IMPL_H
+#define INCLUDED_PHASMA_RFOREST_MODEL_IMPL_H
+
+#include <phasma/rforest_model.h>
+#include <gnuradio/fft/fft.h>
+#include <gnuradio/fft/window.h>
+#include <opencv2/ml.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/core/utility.hpp>
+
+namespace gr
+{
+  namespace phasma
+  {
+
+    class rforest_model_impl : public rforest_model
+    {
+    private:
+
+      size_t d_npredictors;
+      size_t d_nobservations;
+      size_t d_remaining;
+      size_t d_ninport;
+      size_t d_max_depth;
+      size_t d_min_sample_count;
+      size_t d_regression_accu;
+      size_t d_max_categories;
+      size_t d_active_var_count;
+      size_t d_max_iter;
+
+      uint8_t d_use_surrogates;
+      uint8_t d_calc_var_importance;
+
+      std::string d_filename;
+
+      cv::Mat d_predictors;
+      cv::Mat d_labels;
+      cv::Ptr<cv::ml::TrainData> d_train_data;
+
+      /**
+       * Random forest model
+       */
+      cv::Ptr<cv::ml::RTrees> d_rfmodel;
+
+      /**
+       * Auxiliary buffer
+       */
+      gr_complex* d_input;
+
+    public:
+      rforest_model_impl (const size_t npredictors, const size_t nobservations,
+			  const size_t ninport, const size_t max_depth,
+			  const size_t min_sample_count,
+			  const size_t regression_accu,
+			  const uint8_t use_surrogates,
+			  const size_t max_categories,
+			  const uint8_t calc_var_importance,
+			  const size_t active_var_count, const size_t max_iter,
+			  const std::string filename);
+
+      ~rforest_model_impl ();
+
+      // Where all the action really happens
+      int
+      work (int noutput_items, gr_vector_const_void_star &input_items,
+	    gr_vector_void_star &output_items);
+    };
+
+  } // namespace phasma
+} // namespace gr
+
+#endif /* INCLUDED_PHASMA_RFOREST_MODEL_IMPL_H */
+

--- a/swig/phasma_swig.i
+++ b/swig/phasma_swig.i
@@ -8,6 +8,9 @@
 %include "phasma_swig_doc.i"
 
 %{
+#include "phasma/rforest_model.h"
 %}
 
 
+%include "phasma/rforest_model.h"
+GR_SWIG_BLOCK_MAGIC2(phasma, rforest_model);


### PR DESCRIPTION
A block that works as a wrapper for the opencv RandomForest model trainining implementation.
- Trains a RandomForest model
- Exports the trained model in .xml format