### PR TITLE
Signal separation functionality 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,10 @@
 ########################################################################
 cmake_minimum_required(VERSION 2.6)
 project(gr-phasma CXX C)
-enable_testing()
+# Enable C++11 support 
+set(CMAKE_CXX_STANDARD 11) 
+add_definitions(-std=c++11) 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
@@ -90,6 +93,16 @@ find_package(Armadillo REQUIRED)
 if (NOT ARMADILLO_FOUND)
     message(FATAL_ERROR "Armadillo required to compile phasma")
 endif()
+
+########################################################################
+# Find OpenCV
+########################################################################
+find_package(JSONcpp REQUIRED )
+
+if (NOT JSONCPP_FOUND)
+    message(FATAL_ERROR "JSONcpp required to compile phasma")
+endif()
+
 ########################################################################
 # Install directories
 ########################################################################

--- a/cmake/Modules/FindJSONcpp.cmake
+++ b/cmake/Modules/FindJSONcpp.cmake
@@ -1,0 +1,36 @@
+# - Try to find Jsoncpp
+# Once done, this will define
+#
+#  Jsoncpp_FOUND - system has Jsoncpp
+#  Jsoncpp_INCLUDE_DIRS - the Jsoncpp include directories
+#  Jsoncpp_LIBRARIES - link these to use Jsoncpp
+
+INCLUDE(FindPkgConfig)
+
+# Use pkg-config to get hints about paths
+PKG_CHECK_MODULES(JSONCPP "jsoncpp")
+
+FIND_PATH(JSONCPP_INCLUDE_DIR
+    NAMES json
+    ${CMAKE_INSTALL_PREFIX}/include
+    PATHS
+    /usr/local/include
+    /usr/include
+)
+
+FIND_LIBRARY(JSONCPP_LIBRARY
+    NAMES jsoncpp
+    ${CMAKE_INSTALL_PREFIX}/lib
+    ${CMAKE_INSTALL_PREFIX}/lib64
+    PATHS
+    /usr/lib64/
+    /usr/local/lib64/
+    ${JSONCPP_INCLUDE_DIRS}/../lib
+    /usr/local/lib
+    /usr/lib
+)
+LIST(APPEND JSONCPP_LIBRARY ${CMAKE_DL_LIBS})
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(JSONCPP DEFAULT_MSG JSONCPP_LIBRARY JSONCPP_INCLUDE_DIR)
+MARK_AS_ADVANCED(JSONCPP_LIBRARY JSONCPP_INCLUDE_DIR)

--- a/examples/signal_extractor.grc
+++ b/examples/signal_extractor.grc
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <?grc format='1' created='3.7.10'?>
 <flow_graph>
-  <timestamp>Wed Aug 31 13:26:53 2016</timestamp>
+  <timestamp>Sat Feb 18 19:19:52 2017</timestamp>
   <block>
     <key>options</key>
     <param>
@@ -14,7 +14,7 @@
     </param>
     <param>
       <key>category</key>
-      <value>Custom</value>
+      <value>[GRC Hier Blocks]</value>
     </param>
     <param>
       <key>comment</key>
@@ -46,7 +46,7 @@
     </param>
     <param>
       <key>id</key>
-      <value>eigenvalue_detector</value>
+      <value>signal_extractor</value>
     </param>
     <param>
       <key>max_nouts</key>
@@ -82,6 +82,33 @@
     </param>
   </block>
   <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(400, 12)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>fft_size</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>32000</value>
+    </param>
+  </block>
+  <block>
     <key>variable_qtgui_range</key>
     <param>
       <key>comment</key>
@@ -89,15 +116,15 @@
     </param>
     <param>
       <key>value</key>
-      <value>2.5</value>
+      <value>2.3e6</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>True</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(280, 8)</value>
+      <value>(272, 8)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -109,11 +136,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>noise_amp</value>
+      <value>freq_range</value>
     </param>
     <param>
       <key>label</key>
-      <value>Noise Amplitude</value>
+      <value></value>
     </param>
     <param>
       <key>min_len</key>
@@ -125,15 +152,15 @@
     </param>
     <param>
       <key>start</key>
-      <value>0</value>
+      <value>1e6</value>
     </param>
     <param>
       <key>step</key>
-      <value>0.1</value>
+      <value>1e6</value>
     </param>
     <param>
       <key>stop</key>
-      <value>10</value>
+      <value>10e6</value>
     </param>
     <param>
       <key>rangeType</key>
@@ -156,7 +183,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 8)</value>
+      <value>(176, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -168,14 +195,14 @@
     </param>
     <param>
       <key>value</key>
-      <value>1e6</value>
+      <value>10e6</value>
     </param>
   </block>
   <block>
     <key>analog_noise_source_x</key>
     <param>
       <key>amp</key>
-      <value>noise_amp</value>
+      <value>0.2</value>
     </param>
     <param>
       <key>alias</key>
@@ -191,11 +218,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>0</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(280, 336)</value>
+      <value>(528, 92)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -223,7 +250,7 @@
     </param>
     <param>
       <key>seed</key>
-      <value>1</value>
+      <value>0</value>
     </param>
   </block>
   <block>
@@ -242,11 +269,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>0</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(72, 208)</value>
+      <value>(40, 168)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -286,6 +313,191 @@
     </param>
   </block>
   <block>
+    <key>analog_random_source_x</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(40, 360)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>analog_random_source_x_0_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>max</key>
+      <value>255</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>min</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_samps</key>
+      <value>1000</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>byte</value>
+    </param>
+    <param>
+      <key>repeat</key>
+      <value>True</value>
+    </param>
+  </block>
+  <block>
+    <key>analog_sig_source_x</key>
+    <param>
+      <key>amp</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>freq</key>
+      <value>2.3e6</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(40, 256)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>analog_sig_source_x_0_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>offset</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>samp_rate</key>
+      <value>samp_rate</value>
+    </param>
+    <param>
+      <key>waveform</key>
+      <value>analog.GR_COS_WAVE</value>
+    </param>
+  </block>
+  <block>
+    <key>analog_sig_source_x</key>
+    <param>
+      <key>amp</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>freq</key>
+      <value>8e6</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(40, 448)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>analog_sig_source_x_0_0_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>offset</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>samp_rate</key>
+      <value>samp_rate</value>
+    </param>
+    <param>
+      <key>waveform</key>
+      <value>analog.GR_COS_WAVE</value>
+    </param>
+  </block>
+  <block>
     <key>blocks_add_xx</key>
     <param>
       <key>alias</key>
@@ -301,11 +513,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>0</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(480, 240)</value>
+      <value>(584, 192)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -337,6 +549,386 @@
     </param>
   </block>
   <block>
+    <key>blocks_add_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(752, 176)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_add_xx_0_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_complex_to_mag_squared</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(960, 376)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_complex_to_mag_squared_0_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_message_debug</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1152, 144)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_message_debug_0</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_multiply_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1.0/fft_size</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1120, 372)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_const_vxx_0_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_multiply_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(432, 256)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_xx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_multiply_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(440, 448)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_xx_0_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_nlog10_ff</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(872, 364)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_nlog10_ff_0_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>k</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>n</key>
+      <value>10</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_stream_to_vector</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(704, 460)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_stream_to_vector_1</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_items</key>
+      <value>fft_size</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
     <key>blocks_throttle</key>
     <param>
       <key>alias</key>
@@ -352,11 +944,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>0</value>
+      <value>True</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(560, 248)</value>
+      <value>(672, 308)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -392,6 +984,57 @@
     </param>
   </block>
   <block>
+    <key>blocks_vector_to_stream</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1128, 460)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_vector_to_stream_1</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_items</key>
+      <value>fft_size</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
     <key>digital_psk_mod</key>
     <param>
       <key>alias</key>
@@ -411,7 +1054,7 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>0</value>
+      <value>1</value>
     </param>
     <param>
       <key>excess_bw</key>
@@ -419,7 +1062,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(224, 200)</value>
+      <value>(184, 160)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -451,7 +1094,7 @@
     </param>
     <param>
       <key>samples_per_symbol</key>
-      <value>8</value>
+      <value>256</value>
     </param>
     <param>
       <key>verbose</key>
@@ -459,14 +1102,10 @@
     </param>
   </block>
   <block>
-    <key>phasma_eigenvalue_signal_detector</key>
+    <key>digital_psk_mod</key>
     <param>
       <key>alias</key>
       <value></value>
-    </param>
-    <param>
-      <key>actual_bw</key>
-      <value>10e6</value>
     </param>
     <param>
       <key>comment</key>
@@ -477,24 +1116,87 @@
       <value></value>
     </param>
     <param>
-      <key>eigen_samples</key>
-      <value>128</value>
+      <key>differential</key>
+      <value>True</value>
     </param>
     <param>
       <key>_enabled</key>
       <value>1</value>
     </param>
     <param>
-      <key>fft_size</key>
-      <value>1024</value>
-    </param>
-    <param>
-      <key>pfa</key>
-      <value>0.1</value>
+      <key>excess_bw</key>
+      <value>0.35</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(792, 368)</value>
+      <value>(184, 352)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>mod_code</key>
+      <value>"gray"</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>digital_psk_mod_0_0</value>
+    </param>
+    <param>
+      <key>log</key>
+      <value>False</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>constellation_points</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>samples_per_symbol</key>
+      <value>16</value>
+    </param>
+    <param>
+      <key>verbose</key>
+      <value>False</value>
+    </param>
+  </block>
+  <block>
+    <key>fft_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>fft_size</key>
+      <value>fft_size</value>
+    </param>
+    <param>
+      <key>forward</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(872, 432)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -502,19 +1204,102 @@
     </param>
     <param>
       <key>id</key>
-      <value>phasma_eigenvalue_signal_detector_0</value>
+      <value>fft_vxx_1</value>
     </param>
     <param>
-      <key>noise_floor_est_cnt</key>
-      <value>10000</value>
+      <key>type</key>
+      <value>complex</value>
     </param>
     <param>
-      <key>sampling_rate</key>
-      <value>12.5e6</value>
+      <key>maxoutbuf</key>
+      <value>0</value>
     </param>
     <param>
-      <key>smoothing_factor</key>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>nthreads</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>shift</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>window</key>
+      <value>window.blackmanharris(fft_size)</value>
+    </param>
+  </block>
+  <block>
+    <key>phasma_signal_extractor</key>
+    <param>
+      <key>total_bw</key>
+      <value>10e6</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>channel_bw</key>
+      <value>20e3</value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>threshold_db</key>
+      <value>-45</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(944, 148)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>phasma_signal_extractor_0</value>
+    </param>
+    <param>
+      <key>ifft_size</key>
+      <value>64</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>sig_num</key>
       <value>10</value>
+    </param>
+    <param>
+      <key>samp_rate</key>
+      <value>10e6</value>
+    </param>
+    <param>
+      <key>signal_duration</key>
+      <value>100e-3</value>
+    </param>
+    <param>
+      <key>silence_guardband</key>
+      <value>100</value>
     </param>
   </block>
   <block>
@@ -541,7 +1326,7 @@
     </param>
     <param>
       <key>fc</key>
-      <value>0</value>
+      <value>5e6</value>
     </param>
     <param>
       <key>comment</key>
@@ -549,7 +1334,7 @@
     </param>
     <param>
       <key>ctrlpanel</key>
-      <value>False</value>
+      <value>True</value>
     </param>
     <param>
       <key>affinity</key>
@@ -557,15 +1342,15 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>True</value>
     </param>
     <param>
       <key>fftsize</key>
-      <value>4096</value>
+      <value>1024</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(792, 540)</value>
+      <value>(728, 28)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -814,6 +1599,369 @@
     <param>
       <key>units</key>
       <value>dB</value>
+    </param>
+  </block>
+  <block>
+    <key>qtgui_time_sink_x</key>
+    <param>
+      <key>autoscale</key>
+      <value>False</value>
+    </param>
+    <param>
+      <key>axislabels</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>ctrlpanel</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>entags</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(944, 60)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>grid</key>
+      <value>False</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>qtgui_time_sink_x_0</value>
+    </param>
+    <param>
+      <key>legend</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>alpha1</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color1</key>
+      <value>"blue"</value>
+    </param>
+    <param>
+      <key>label1</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker1</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style1</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width1</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha10</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color10</key>
+      <value>"blue"</value>
+    </param>
+    <param>
+      <key>label10</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker10</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style10</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width10</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha2</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color2</key>
+      <value>"red"</value>
+    </param>
+    <param>
+      <key>label2</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker2</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style2</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width2</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha3</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color3</key>
+      <value>"green"</value>
+    </param>
+    <param>
+      <key>label3</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker3</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style3</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width3</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha4</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color4</key>
+      <value>"black"</value>
+    </param>
+    <param>
+      <key>label4</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker4</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style4</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width4</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha5</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color5</key>
+      <value>"cyan"</value>
+    </param>
+    <param>
+      <key>label5</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker5</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style5</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width5</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha6</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color6</key>
+      <value>"magenta"</value>
+    </param>
+    <param>
+      <key>label6</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker6</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style6</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width6</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha7</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color7</key>
+      <value>"yellow"</value>
+    </param>
+    <param>
+      <key>label7</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker7</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style7</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width7</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha8</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color8</key>
+      <value>"dark red"</value>
+    </param>
+    <param>
+      <key>label8</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker8</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style8</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width8</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha9</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color9</key>
+      <value>"dark green"</value>
+    </param>
+    <param>
+      <key>label9</key>
+      <value></value>
+    </param>
+    <param>
+      <key>marker9</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>style9</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>width9</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>name</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>nconnections</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>size</key>
+      <value>fft_size</value>
+    </param>
+    <param>
+      <key>srate</key>
+      <value>samp_rate</value>
+    </param>
+    <param>
+      <key>tr_chan</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>tr_delay</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>tr_level</key>
+      <value>0.0</value>
+    </param>
+    <param>
+      <key>tr_mode</key>
+      <value>qtgui.TRIG_MODE_FREE</value>
+    </param>
+    <param>
+      <key>tr_slope</key>
+      <value>qtgui.TRIG_SLOPE_POS</value>
+    </param>
+    <param>
+      <key>tr_tag</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>update_time</key>
+      <value>0.10</value>
+    </param>
+    <param>
+      <key>ylabel</key>
+      <value>Amplitude</value>
+    </param>
+    <param>
+      <key>yunit</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>ymax</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>ymin</key>
+      <value>-1</value>
     </param>
   </block>
   <block>
@@ -1996,11 +3144,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 468)</value>
+      <value>(496, 548)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2157,9 +3305,9 @@
   </block>
   <connection>
     <source_block_id>analog_noise_source_x_0</source_block_id>
-    <sink_block_id>blocks_add_xx_0</sink_block_id>
+    <sink_block_id>blocks_add_xx_0_0</sink_block_id>
     <source_key>0</source_key>
-    <sink_key>1</sink_key>
+    <sink_key>0</sink_key>
   </connection>
   <connection>
     <source_block_id>analog_random_source_x_0</source_block_id>
@@ -2168,38 +3316,128 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>analog_random_source_x_0_0</source_block_id>
+    <sink_block_id>digital_psk_mod_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>analog_sig_source_x_0_0</source_block_id>
+    <sink_block_id>blocks_multiply_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>analog_sig_source_x_0_0_0</source_block_id>
+    <sink_block_id>blocks_multiply_xx_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_add_xx_0</source_block_id>
+    <sink_block_id>blocks_add_xx_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_add_xx_0_0</source_block_id>
     <sink_block_id>blocks_throttle_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>blocks_throttle_0</source_block_id>
-    <sink_block_id>phasma_eigenvalue_signal_detector_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>blocks_throttle_0</source_block_id>
+    <source_block_id>blocks_add_xx_0_0</source_block_id>
     <sink_block_id>qtgui_freq_sink_x_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>digital_psk_mod_0</source_block_id>
+    <source_block_id>blocks_complex_to_mag_squared_0_0</source_block_id>
+    <sink_block_id>blocks_nlog10_ff_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_complex_to_mag_squared_0_0</source_block_id>
+    <sink_block_id>phasma_signal_extractor_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_multiply_const_vxx_0_0</source_block_id>
+    <sink_block_id>blocks_complex_to_mag_squared_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_multiply_xx_0</source_block_id>
     <sink_block_id>blocks_add_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>uhd_usrp_source_0</source_block_id>
-    <sink_block_id>phasma_eigenvalue_signal_detector_0</sink_block_id>
+    <source_block_id>blocks_multiply_xx_0_0</source_block_id>
+    <sink_block_id>blocks_add_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_nlog10_ff_0_0</source_block_id>
+    <sink_block_id>qtgui_time_sink_x_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_stream_to_vector_1</source_block_id>
+    <sink_block_id>fft_vxx_1</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_throttle_0</source_block_id>
+    <sink_block_id>blocks_stream_to_vector_1</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_vector_to_stream_1</source_block_id>
+    <sink_block_id>blocks_multiply_const_vxx_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_vector_to_stream_1</source_block_id>
+    <sink_block_id>phasma_signal_extractor_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>digital_psk_mod_0</source_block_id>
+    <sink_block_id>blocks_multiply_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>digital_psk_mod_0_0</source_block_id>
+    <sink_block_id>blocks_multiply_xx_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>fft_vxx_1</source_block_id>
+    <sink_block_id>blocks_vector_to_stream_1</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>phasma_signal_extractor_0</source_block_id>
+    <sink_block_id>blocks_message_debug_0</sink_block_id>
+    <source_key>out</source_key>
+    <sink_key>print</sink_key>
+  </connection>
+  <connection>
     <source_block_id>uhd_usrp_source_0</source_block_id>
-    <sink_block_id>qtgui_freq_sink_x_0</sink_block_id>
+    <sink_block_id>blocks_stream_to_vector_1</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -20,5 +20,6 @@
 install(FILES
     phasma_rforest_model.xml
     phasma_eigenvalue_signal_detector.xml 
-    phasma_opencv_predict.xml DESTINATION share/gnuradio/grc/blocks
+    phasma_opencv_predict.xml
+    phasma_signal_extractor.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/phasma_signal_extractor.xml
+++ b/grc/phasma_signal_extractor.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<block>
+  <name>Signal Extractor</name>
+  <key>phasma_signal_extractor</key>
+  <category>[phasma]</category>
+  <import>import phasma</import>
+  <make>phasma.signal_extractor($samp_rate, $total_bw, $channel_bw, $ifft_size, 
+  								$silence_guardband, $signal_duration, $threshold_db,
+  								$sig_num)</make>
+  						
+  <param>
+    <name>Sampling Rate</name>
+    <key>samp_rate</key>
+    <value>12.5e6</value>
+    <type>float</type>
+  </param>
+  
+  <param>
+    <name>Actual Bandwidth</name>
+    <key>total_bw</key>
+    <value>10e6</value>
+    <type>float</type>
+  </param>
+
+  <param>
+    <name>Channel Bandwidth</name>
+    <key>channel_bw</key>
+    <value>20e3</value>
+    <type>float</type>
+  </param>
+  
+  <param>
+    <name>IFFT Size</name>
+    <key>ifft_size</key>
+    <value>100</value>
+    <type>int</type>
+  </param>
+  
+  <param>
+    <name>Silence Guardband</name>
+    <key>silence_guardband</key>
+    <value>5</value>
+    <type>int</type>
+  </param>
+  
+  <param>
+    <name>Signal Duration</name>
+    <key>signal_duration</key>
+    <value>100e-3</value>
+    <type>float</type>
+  </param>
+
+  <param>
+    <name>Energy Threshold (dB)</name>
+    <key>threshold_db</key>
+    <value>-100</value>
+    <type>float</type>
+  </param>
+
+  <param>
+    <name>Number of Signals</name>
+    <key>sig_num</key>
+    <value>10</value>
+    <type>int</type>
+  </param>
+  
+  <sink>
+    <name>in</name>
+    <type>float</type>
+  </sink>
+  
+  <sink>
+    <name>in</name>
+    <type>complex</type>
+  </sink>
+
+  <sink>
+    <name>threshold</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+
+  <source>
+    <name>out</name>
+    <type>message</type>
+  </source>
+</block>

--- a/include/phasma/CMakeLists.txt
+++ b/include/phasma/CMakeLists.txt
@@ -21,9 +21,11 @@
 # Install public header files
 ########################################################################
 install(FILES
+    utils/sigMF.h
     api.h
     log.h
     rforest_model.h
     eigenvalue_signal_detector.h 
-    opencv_predict.h DESTINATION include/phasma
+    opencv_predict.h
+    signal_extractor.h DESTINATION include/phasma
 )

--- a/include/phasma/signal_extractor.h
+++ b/include/phasma/signal_extractor.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_PHASMA_SIGNAL_EXTRACTOR_H
+#define INCLUDED_PHASMA_SIGNAL_EXTRACTOR_H
+
+#include <phasma/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace phasma {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup phasma
+     *
+     */
+    class PHASMA_API signal_extractor : virtual public gr::sync_block
+    {
+     public:
+      typedef boost::shared_ptr<signal_extractor> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of phasma::signal_extractor.
+       *
+       * To avoid accidental use of raw pointers, phasma::signal_extractor's
+       * constructor is in a private implementation
+       * class. phasma::signal_extractor::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make(float samp_rate, float total_bw, float channel_bw,
+		       size_t ifft_size, size_t silence_guardband,
+		       float signal_duration, float threshold_db, size_t sig_num);
+    };
+
+  } // namespace phasma
+} // namespace gr
+
+#endif /* INCLUDED_PHASMA_SIGNAL_EXTRACTOR_H */
+

--- a/include/phasma/utils/sigMF.h
+++ b/include/phasma/utils/sigMF.h
@@ -1,0 +1,134 @@
+/*
+ * sigMF.h
+ *
+ *  Created on: Feb 24, 2017
+ *      Author: ctriant
+ */
+
+#ifndef LIB_UTILS_SIGMF_H_
+#define LIB_UTILS_SIGMF_H_
+
+#include <string>
+
+class sigMF
+{
+private:
+
+  /* Global object fields */
+  std::string d_datatype;
+  std::string d_datapath;
+  std::string d_version;
+  std::string d_sha512;
+  uint64_t d_offset;
+  std::string d_description;
+  std::string d_author;
+  std::string d_date;
+  std::string d_license;
+  std::string d_hw;
+
+  /* Capture object fileds */
+  size_t d_capture_sample_start;
+  double d_frequency;
+  double d_sample_rate;
+  std::string d_time;
+
+  /* Annotation object fileds */
+  size_t d_annotation_samples_start;
+  size_t d_sample_count;
+  std::string d_comment;
+  double d_freq_lower_edge;
+  double d_freq_upper_edge;
+
+public:
+  sigMF (std::string datatype, std::string datapath, std::string version,
+	 size_t capture_sample_start, size_t annotation_sample_start,
+	 size_t sample_count);
+
+  sigMF (std::string datatype, std::string datapath, std::string version,
+  	 size_t capture_sample_start, double sample_rate, std::string time,
+	 size_t annotation_sample_start, size_t sample_count, double freq_lower_edge,
+	 double freq_upper_edge, std::string comment);
+
+  virtual
+  ~sigMF ();
+  size_t
+  getAnnotationSamplesStart () const;
+  void
+  setAnnotationSamplesStart (size_t annotationSamplesStart);
+  const std::string&
+  getAuthor () const;
+  void
+  setAuthor (const std::string& author);
+  size_t
+  getCaptureSampleStart () const;
+  void
+  setCaptureSampleStart (size_t captureSampleStart);
+  const std::string&
+  getComment () const;
+  void
+  setComment (const std::string& comment);
+  const std::string&
+  getDatapath () const;
+  void
+  setDatapath (const std::string& datapath);
+  const std::string&
+  getDatatype () const;
+  void
+  setDatatype (const std::string& datatype);
+  const std::string&
+  getDate () const;
+  void
+  setDate (const std::string& date);
+  const std::string&
+  getDescription () const;
+  void
+  setDescription (const std::string& description);
+  double
+  getFreqLowerEdge () const;
+  void
+  setFreqLowerEdge (double freqLowerEdge);
+  double
+  getFreqUpperEdge () const;
+  void
+  setFreqUpperEdge (double freqUpperEdge);
+  double
+  getFrequency () const;
+  void
+  setFrequency (double frequency);
+  const std::string&
+  getHw () const;
+  void
+  setHw (const std::string& hw);
+  const std::string&
+  getLicense () const;
+  void
+  setLicense (const std::string& license);
+  uint64_t
+  getOffset () const;
+  void
+  setOffset (uint64_t offset);
+  size_t
+  getSampleCount () const;
+  void
+  setSampleCount (size_t sampleCount);
+  double
+  getSampleRate () const;
+  void
+  setSampleRate (double sampleRate);
+  const std::string&
+  getSha512 () const;
+  void
+  setSha512 (const std::string& sha512);
+  const std::string&
+  getTime () const;
+  void
+  setTime (const std::string& time);
+  const std::string&
+  getVersion () const;
+  void
+  setVersion (const std::string& version);
+  std::string
+  toJSON();
+};
+
+#endif /* LIB_UTILS_SIGMF_H_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,16 +23,19 @@
 include(GrPlatform) #define LIB_SUFFIX
 
 include_directories(${Boost_INCLUDE_DIR}
-                    ${ARMADILLO_INCLUDE_DIRS})
+                    ${ARMADILLO_INCLUDE_DIRS}
+                    ${JSONCPP_INCLUDE_DIR})
                     
 link_directories(${Boost_LIBRARY_DIRS})
 
 include_directories(${ARMADILLO_INCLUDE_DIRS})
 
 list(APPEND phasma_sources
+    utils/sigMF.cc
     rforest_model_impl.cc
     eigenvalue_signal_detector_impl.cc
     opencv_predict_impl.cc
+    signal_extractor_impl.cc
 )
 
 set(phasma_sources "${phasma_sources}" PARENT_SCOPE)
@@ -45,6 +48,7 @@ list(APPEND phasma_libs ${Boost_LIBRARIES}
                             ${OpenCV_LIBS}
                             ${ARMADILLO_LIBRARIES}
                             ${GNURADIO_ALL_LIBRARIES}
+                            ${JSONCPP_LIBRARY}
 )
 
 add_library(gnuradio-phasma SHARED ${phasma_sources})

--- a/lib/eigenvalue_signal_detector_impl.cc
+++ b/lib/eigenvalue_signal_detector_impl.cc
@@ -33,195 +33,209 @@
 
 #include "eigenvalue_signal_detector_impl.h"
 
-namespace gr {
-namespace phasma {
-
-eigenvalue_signal_detector::sptr eigenvalue_signal_detector::make(
-		size_t eigen_samples, size_t smoothing_factor, double pfa,
-		size_t fft_size, float sampling_rate, float actual_bw, size_t noise_floor_est_cnt) {
-	return gnuradio::get_initial_sptr(
-			new eigenvalue_signal_detector_impl(eigen_samples, smoothing_factor,
-					pfa, fft_size, sampling_rate, actual_bw, noise_floor_est_cnt));
-}
-
-/*
- * The private constructor
- */
-eigenvalue_signal_detector_impl::eigenvalue_signal_detector_impl(
-		size_t eigen_samples, size_t smoothing_factor,
-		double pfa, size_t fft_size, float sampling_rate, float actual_bw,
-		size_t noise_floor_est_cnt) :
-		gr::sync_block("eigenvalue_signal_detector",
-				gr::io_signature::make(1, 1, sizeof(gr_complex)),
-				gr::io_signature::make(0, 0, 0)),
-				d_eigen_samples(eigen_samples),
-				d_smoothing_factor(smoothing_factor), 
-				d_pfa(pfa),
-			    d_fft_size(fft_size), 
-				d_sampling_rate(sampling_rate),
-				d_bw(actual_bw * pow(actual_bw, 6)), 
-				d_num_samps_to_discard(
-				ceil(
-						(d_fft_size
-								- (d_bw * (float) d_fft_size / d_sampling_rate))
-								/ 2)), d_num_samps_per_side(
-				(d_fft_size / 2) - d_num_samps_to_discard),
-				d_subcarriers_num(2 * d_num_samps_per_side), 
-				d_norm_factor(1 / (float) d_fft_size, 0), 
-				d_noise_floor_est_cnt(noise_floor_est_cnt),
-				d_noise_floor_est(true)
-
+namespace gr
 {
-	/* Process in a per-FFT basis */
-	set_output_multiple (d_fft_size);
-	
-    /* Compute the decision threshold for the eigenvalue detector */       
-	d_eigen_threshold = eigen_threshold_estimation();
-	PHASMA_DEBUG("Eigenvalue threshold %f \n", d_eigen_threshold);
-	
-	d_fft = new fft::fft_complex(d_fft_size, true, 1);
-	d_shift = (float*) volk_malloc((d_subcarriers_num) * sizeof(float), 32);
-	
-	d_blackmann_harris_win = (float*) volk_malloc(d_fft_size * sizeof(float),
-			32); 
-	
-	/* Calculation of Blackmann-Harris window */
-	for (size_t i = 0; i < d_fft_size; i++) {
-		d_blackmann_harris_win[i] = 0.35875
-				- 0.48829 * cos((2 * M_PI * i) / (d_fft_size - 1))
-				+ 0.14128 * cos((4 * M_PI * i) / (d_fft_size - 1))
-				- 0.01168 * cos((6 * M_PI * i) / (d_fft_size - 1));
+  namespace phasma
+  {
+
+    eigenvalue_signal_detector::sptr
+    eigenvalue_signal_detector::make (size_t eigen_samples,
+				      size_t smoothing_factor, double pfa,
+				      size_t fft_size, float sampling_rate,
+				      float actual_bw,
+				      size_t noise_floor_est_cnt)
+    {
+      return gnuradio::get_initial_sptr (
+	  new eigenvalue_signal_detector_impl (eigen_samples, smoothing_factor,
+					       pfa, fft_size, sampling_rate,
+					       actual_bw, noise_floor_est_cnt));
+    }
+
+    /*
+     * The private constructor
+     */
+    eigenvalue_signal_detector_impl::eigenvalue_signal_detector_impl (
+	size_t eigen_samples, size_t smoothing_factor, double pfa,
+	size_t fft_size, float sampling_rate, float actual_bw,
+	size_t noise_floor_est_cnt) :
+	    gr::sync_block ("eigenvalue_signal_detector",
+			    gr::io_signature::make (1, 1, sizeof(gr_complex)),
+			    gr::io_signature::make (0, 0, 0)),
+	    d_eigen_samples (eigen_samples),
+	    d_smoothing_factor (smoothing_factor),
+	    d_pfa (pfa),
+	    d_fft_size (fft_size),
+	    d_sampling_rate (sampling_rate),
+	    d_bw (actual_bw * pow (actual_bw, 6)),
+	    d_num_samps_to_discard (
+		ceil (
+		    (d_fft_size - (d_bw * (float) d_fft_size / d_sampling_rate))
+			/ 2)),
+	    d_num_samps_per_side ((d_fft_size / 2) - d_num_samps_to_discard),
+	    d_subcarriers_num (2 * d_num_samps_per_side),
+	    d_norm_factor (1 / (float) d_fft_size, 0),
+	    d_noise_floor_est_cnt (noise_floor_est_cnt),
+	    d_noise_floor_est (true)
+
+    {
+      /* Process in a per-FFT basis */
+      set_output_multiple (d_fft_size);
+
+      /* Compute the decision threshold for the eigenvalue detector */
+      d_eigen_threshold = eigen_threshold_estimation ();
+      PHASMA_DEBUG("Eigenvalue threshold %f \n", d_eigen_threshold);
+
+      d_fft = new fft::fft_complex (d_fft_size, true, 1);
+      d_shift = (float*) volk_malloc ((d_subcarriers_num) * sizeof(float), 32);
+
+      d_blackmann_harris_win = (float*) volk_malloc (d_fft_size * sizeof(float),
+						     32);
+
+      /* Calculation of Blackmann-Harris window */
+      for (size_t i = 0; i < d_fft_size; i++) {
+	d_blackmann_harris_win[i] = 0.35875
+	    - 0.48829 * cos ((2 * M_PI * i) / (d_fft_size - 1))
+	    + 0.14128 * cos ((4 * M_PI * i) / (d_fft_size - 1))
+	    - 0.01168 * cos ((6 * M_PI * i) / (d_fft_size - 1));
+      }
+      d_psd = (float*) volk_malloc (d_fft_size * sizeof(float), 32);
+      d_noise_floor = (float*) volk_malloc (d_fft_size * sizeof(float), 32);
+      memset (d_noise_floor, 0, d_fft_size);
+
+    }
+
+    eigenvalue_signal_detector_impl::~eigenvalue_signal_detector_impl ()
+    {
+      delete d_fft;
+      volk_free (d_blackmann_harris_win);
+      volk_free (d_psd);
+      volk_free (d_noise_floor);
+      volk_free (d_shift);
+    }
+
+    float
+    eigenvalue_signal_detector_impl::eigen_threshold_estimation ()
+    {
+      float threshold;
+      float p_1;
+      float p_2;
+
+      /* Maximum-minimum eigenvalue (MME) algorithm threshold */
+      p_1 = pow (sqrt (d_eigen_samples) + sqrt (d_smoothing_factor), 2)
+	  / pow (sqrt (d_eigen_samples) - sqrt (d_smoothing_factor), 2);
+
+      p_2 = 1
+	  + (pow (sqrt (d_eigen_samples) + sqrt (d_smoothing_factor),
+		  (-1) * 2 / 3.0)
+	      / pow (d_eigen_samples * d_smoothing_factor, 1 / 6.0)) * 0.59;
+
+      threshold = p_1 / p_2;
+
+      return threshold;
+    }
+
+    int
+    eigenvalue_signal_detector_impl::work (
+	int noutput_items, gr_vector_const_void_star &input_items,
+	gr_vector_void_star &output_items)
+    {
+
+      const gr_complex *in = (const gr_complex*) input_items[0];
+
+      float ratio;
+      size_t noise_free = 0;
+
+      /*
+       * TODO: Actually the number of possible iterations is larger.
+       * Number of input samples is a multiple of fft_size.
+       * For now a kind of decimation is performed and only the first chunk of
+       * fft_size samples is handled.
+       */
+
+      size_t iter_num = d_fft_size / d_eigen_samples;
+      const gr_complex *win_ptr;
+      arma::cx_fmat X = arma::cx_fmat (d_eigen_samples, d_smoothing_factor);
+      arma::cx_fmat R;
+      arma::cx_fcolvec eigval;
+      std::vector<float> feigval (d_smoothing_factor);
+      // Handle all possible chunks of eigen_samples
+      for (size_t it = 0; it < iter_num; it++) {
+	// Last iteration should use previous samples
+	if (it == iter_num - 1) {
+	  win_ptr = &in[(it - 1) + d_eigen_samples - d_smoothing_factor - 1];
 	}
-	d_psd = (float*) volk_malloc(d_fft_size * sizeof(float), 32);
-	d_noise_floor = (float*) volk_malloc(d_fft_size * sizeof(float), 32);
-	memset(d_noise_floor, 0, d_fft_size);
-	
-}
+	else {
+	  win_ptr = &in[it];
+	}
+	memcpy (&X[0], win_ptr, d_eigen_samples * sizeof(gr_complex));
+	for (size_t i = 1; i < d_smoothing_factor; i++) {
+	  memcpy (&X[(d_eigen_samples * i)], &win_ptr[i],
+		  d_eigen_samples * sizeof(gr_complex));
+	}
 
-eigenvalue_signal_detector_impl::~eigenvalue_signal_detector_impl() {
-	delete d_fft;
-	volk_free(d_blackmann_harris_win);
-	volk_free(d_psd);
-	volk_free(d_noise_floor);
-	volk_free (d_shift);
-}
+	R = arma::cov (X);
+	arma::eig_gen (eigval, R);
+	for (size_t t = 0; t < eigval.n_elem; t++) {
+	  feigval[t] = std::abs (eigval (t));
+	}
+	std::sort (feigval.begin (), feigval.end (), std::greater<float> ());
+	/* Maximum-minimum eigenvalue detection algorithm */
+	ratio = feigval[0] / feigval[feigval.size () - 1];
 
-float 
-eigenvalue_signal_detector_impl::eigen_threshold_estimation() {
-	float threshold;
-	float p_1;
-	float p_2;
-
-	/* Maximum-minimum eigenvalue (MME) algorithm threshold */
-	p_1 = pow(sqrt(d_eigen_samples) + sqrt(d_smoothing_factor), 2)
-			/ pow(sqrt(d_eigen_samples) - sqrt(d_smoothing_factor), 2);
-
-	p_2 = 1
-			+ (pow(sqrt(d_eigen_samples) + sqrt(d_smoothing_factor),
-					(-1) * 2 / 3.0)
-					/ pow(d_eigen_samples * d_smoothing_factor, 1 / 6.0))
-					* 0.59;
-
-	threshold = p_1 / p_2;
-
-	return threshold;
-}
-
-int 
-eigenvalue_signal_detector_impl::work(int noutput_items,
-		gr_vector_const_void_star &input_items,
-		gr_vector_void_star &output_items) {
-	
-	const gr_complex *in = (const gr_complex*) input_items[0];
-	
-	float ratio;
-	size_t noise_free = 0;
-	
-	/* 
-	 * TODO: Actually the number of possible iterations is larger.
-	 * Number of input samples is a multiple of fft_size.
-	 * For now a kind of decimation is performed and only the first chunk of
-	 * fft_size samples is handled.
-	 */
-	
-	size_t iter_num = d_fft_size/d_eigen_samples;
-	const gr_complex *win_ptr;
-	arma::cx_fmat X = arma::cx_fmat(d_eigen_samples, d_smoothing_factor);
-	arma::cx_fmat R;
-	arma::cx_fcolvec eigval;
-	std::vector<float> feigval(d_smoothing_factor);
-	// Handle all possible chunks of eigen_samples
-	for (size_t it=0; it < iter_num; it++) {
-		// Last iteration should use previous samples
-		if (it == iter_num - 1) {
-			win_ptr = &in[(it - 1) + d_eigen_samples - d_smoothing_factor -1];
-		} else {
-			win_ptr = &in[it];
-		}
-		memcpy (&X[0], win_ptr, d_eigen_samples*sizeof(gr_complex));       
-		for (size_t i = 1; i < d_smoothing_factor; i++) {
-			memcpy(&X[(d_eigen_samples * i)], &win_ptr[i],
-					d_eigen_samples  * sizeof(gr_complex));
-		}
-		
-		R = arma::cov(X);
-		arma::eig_gen(eigval, R);
-		for (size_t t = 0; t < eigval.n_elem; t++) {
-			feigval[t] = std::abs(eigval(t));
-		}
-		std::sort(feigval.begin(), feigval.end(), std::greater<float>()); 
-		/* Maximum-minimum eigenvalue detection algorithm */
-		ratio = feigval[0] / feigval[feigval.size() - 1];
-		
-		if (ratio <= d_eigen_threshold) {
-			noise_free++;
-			PHASMA_DEBUG("***** Signal Absent *****");
-			PHASMA_DEBUG("Eigenvalues num: %d", eigval.n_elem);
-			PHASMA_DEBUG("Min Eigenvalue: %f", feigval[feigval.size() - 1]);
-			PHASMA_DEBUG("Max Eigenvalue: %f", feigval[0]);
-			PHASMA_DEBUG("Ratio: %f", ratio);
-			PHASMA_DEBUG("Threshold: %f \n", d_eigen_threshold);
-		}
-		else {
+	if (ratio <= d_eigen_threshold) {
+	  noise_free++;
+	  PHASMA_DEBUG("***** Signal Absent *****"); PHASMA_DEBUG("Eigenvalues num: %d", eigval.n_elem); PHASMA_DEBUG("Min Eigenvalue: %f", feigval[feigval.size() - 1]); PHASMA_DEBUG("Max Eigenvalue: %f", feigval[0]); PHASMA_DEBUG("Ratio: %f", ratio); PHASMA_DEBUG("Threshold: %f \n", d_eigen_threshold);
+	}
+	else {
 //			PHASMA_DEBUG("I see land!");
-		}
 	}
-	
-	if (d_noise_floor_est && noise_free == iter_num
-			&& d_noise_floor_est_cnt > 0) {
-		PHASMA_DEBUG("Ok sailor! Bring me a good bottle of noise-floor rum.");
-		noise_floor_estimation(in, noutput_items);
-		/* Perform shifting and cropping on squared magnitude max noise-floor*/
-		memcpy(&d_shift[0],
-				&d_noise_floor[(d_fft_size / 2) + d_num_samps_to_discard],
-				sizeof(float) * (d_num_samps_per_side));
-		memcpy(&d_shift[d_num_samps_per_side], &d_noise_floor[0],
-				sizeof(float) * (d_num_samps_per_side));
-		for (size_t t=0; t<d_subcarriers_num; t++){
-			std::cout << 10*log10(d_shift[t]) << std::endl;
-		}
+      }
+
+      if (d_noise_floor_est && noise_free == iter_num
+	  && d_noise_floor_est_cnt > 0) {
+	PHASMA_DEBUG("Ok sailor! Bring me a good bottle of noise-floor rum.");
+	noise_floor_estimation (in, noutput_items);
+	/* Perform shifting and cropping on squared magnitude max noise-floor*/
+	memcpy (&d_shift[0],
+		&d_noise_floor[(d_fft_size / 2) + d_num_samps_to_discard],
+		sizeof(float) * (d_num_samps_per_side));
+	memcpy (&d_shift[d_num_samps_per_side], &d_noise_floor[0],
+		sizeof(float) * (d_num_samps_per_side));
+	for (size_t t = 0; t < d_subcarriers_num; t++) {
+	  std::cout << 10 * log10 (d_shift[t]) << std::endl;
 	}
-	
-	return noutput_items;
-	
-}
+      }
 
-void eigenvalue_signal_detector_impl::noise_floor_estimation(
-		const gr_complex* in, int available_items) {
+      return noutput_items;
 
-	d_noise_floor_est_cnt--; /* Apply window, check if need unaligned version */
-	volk_32fc_32f_multiply_32fc(&d_fft->get_inbuf()[0], in,
-			&d_blackmann_harris_win[0], d_fft_size);
-	d_fft->execute(); /* De-normalize with the size of wide FFT */
-	volk_32fc_s32fc_multiply_32fc(d_fft->get_outbuf(), d_fft->get_outbuf(),
-			d_norm_factor, d_fft_size); /* Calculate abs^2  (no dB scale) */
-	volk_32fc_magnitude_squared_32f(d_psd, d_fft->get_outbuf(), d_fft_size); /* Get maximum for each sub-carrier*/
-	for (size_t b = 0; b < d_fft_size; b++) {
-		d_noise_floor[b] = boost::minmax(d_noise_floor[b], d_psd[b]).get<1>();
-	}
+    }
 
-}
+    void
+    eigenvalue_signal_detector_impl::noise_floor_estimation (
+	const gr_complex* in, int available_items)
+    {
 
-} /* namespace phasma */
+      d_noise_floor_est_cnt--;
+
+      /* Apply window, check if need unaligned version */
+      volk_32fc_32f_multiply_32fc (&d_fft->get_inbuf ()[0], in,
+				   &d_blackmann_harris_win[0], d_fft_size);
+      d_fft->execute ();
+
+      /* De-normalize with the size of wide FFT */
+      volk_32fc_s32fc_multiply_32fc (d_fft->get_outbuf (), d_fft->get_outbuf (),
+				     d_norm_factor, d_fft_size);
+
+      /* Calculate abs^2  (no dB scale) */
+      volk_32fc_magnitude_squared_32f (d_psd, d_fft->get_outbuf (), d_fft_size);
+
+      /* Get maximum for each sub-carrier*/
+      for (size_t b = 0; b < d_fft_size; b++) {
+	d_noise_floor[b] = boost::minmax (d_noise_floor[b], d_psd[b]).get<1> ();
+      }
+
+    }
+
+  } /* namespace phasma */
 } /* namespace gr */
 

--- a/lib/eigenvalue_signal_detector_impl.h
+++ b/lib/eigenvalue_signal_detector_impl.h
@@ -24,87 +24,90 @@
 #include <phasma/eigenvalue_signal_detector.h>
 #include <gnuradio/fft/fft.h>
 
-namespace gr {
-namespace phasma {
+namespace gr
+{
+  namespace phasma
+  {
 
-class eigenvalue_signal_detector_impl: public eigenvalue_signal_detector {
-private:
-	size_t d_eigen_samples;
-	size_t d_smoothing_factor;
-	
-	/* The FFT size */       
-	const size_t d_fft_size;
+    class eigenvalue_signal_detector_impl : public eigenvalue_signal_detector
+    {
+    private:
+      size_t d_eigen_samples;
+      size_t d_smoothing_factor;
 
-	double d_pfa;
-	
-	/* Decision threshold of eigenvalue-based method */       
-	float d_eigen_threshold;
-	
-	/* Operational sampling rate */
-	const double d_sampling_rate;
-	
-    /* The available bandwidth in MHz */
-	float d_bw;
-	
-    /* Number of samples to discard per side in the observed spectrum band*/
-	size_t d_num_samps_to_discard; 
-	
-	/* Number of samples per side in the observed spectrum band */
-	size_t d_num_samps_per_side;
-	
-    /* Number of sub-carriers */
-	size_t d_subcarriers_num;
-	
-    /* Blackmann-Harris window */
-	float* d_blackmann_harris_win; 
-	
-	/* Vector to store the estimated PSD */
-	float* d_psd; 
-	
-	/* Auxiliary FFT vector */
-	fft::fft_complex* d_fft; 
-	
-	 /* Auxiliary vector to store FFT shift */
-	float* d_shift;
-	
-    /* Vector that holds the noise-floor estimation */
-	float* d_noise_floor;
-	
-	/* Normalization factor used in the calculation of the PSD */
-	gr_complex d_norm_factor;
-	
-	/* The number of requested noise-floor estimations */
-	size_t d_noise_floor_est_cnt;
-	
-	bool d_noise_floor_est;
-	
-	static bool sort_using_greater_than(float u, float v) {
-		return u > v;
-	}
+      /* The FFT size */
+      const size_t d_fft_size;
 
-	float
-	eigen_threshold_estimation();
-	
-	void 
-	noise_floor_estimation(const gr_complex* in, int available_items);
+      double d_pfa;
 
-public:
-	eigenvalue_signal_detector_impl(size_t eigen_samples,
-									size_t smoothing_factor, 
-									double pfa,
-									size_t fft_size,
-									float sampling_rate,
-									float actual_bw,
-									size_t noise_floor_est_cnt);
-	
-	~eigenvalue_signal_detector_impl();
+      /* Decision threshold of eigenvalue-based method */
+      float d_eigen_threshold;
 
-	int
-	work(int noutput_items, gr_vector_const_void_star &input_items,
-			gr_vector_void_star &output_items);
-};
+      /* Operational sampling rate */
+      const double d_sampling_rate;
 
-} // namespace phasma
+      /* The available bandwidth in MHz */
+      float d_bw;
+
+      /* Number of samples to discard per side in the observed spectrum band*/
+      size_t d_num_samps_to_discard;
+
+      /* Number of samples per side in the observed spectrum band */
+      size_t d_num_samps_per_side;
+
+      /* Number of sub-carriers */
+      size_t d_subcarriers_num;
+
+      /* Blackmann-Harris window */
+      float* d_blackmann_harris_win;
+
+      /* Vector to store the estimated PSD */
+      float* d_psd;
+
+      /* Auxiliary FFT vector */
+      fft::fft_complex* d_fft;
+
+      /* Auxiliary vector to store FFT shift */
+      float* d_shift;
+
+      /* Vector that holds the noise-floor estimation */
+      float* d_noise_floor;
+
+      /* Normalization factor used in the calculation of the PSD */
+      gr_complex d_norm_factor;
+
+      /* The number of requested noise-floor estimations */
+      size_t d_noise_floor_est_cnt;
+
+      bool d_noise_floor_est;
+
+      static bool
+      sort_using_greater_than (float u, float v)
+      {
+	return u > v;
+      }
+
+      float
+      eigen_threshold_estimation ();
+
+      void
+      noise_floor_estimation (const gr_complex* in, int available_items);
+
+    public:
+      eigenvalue_signal_detector_impl (size_t eigen_samples,
+				       size_t smoothing_factor, double pfa,
+				       size_t fft_size, float sampling_rate,
+				       float actual_bw,
+				       size_t noise_floor_est_cnt);
+
+      ~eigenvalue_signal_detector_impl ();
+
+      int
+      work (int noutput_items, gr_vector_const_void_star &input_items,
+	    gr_vector_void_star &output_items);
+    };
+
+  } // namespace phasma
 } // namespace gr
 
 #endif /* INCLUDED_PHASMA_EIGENVALUE_SIGNAL_DETECTOR_IMPL_H */

--- a/lib/signal_extractor_impl.cc
+++ b/lib/signal_extractor_impl.cc
@@ -1,0 +1,289 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Kostis Triantafyllakis.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <volk/volk.h>
+#include <phasma/utils/sigMF.h>
+#include <chrono>
+#include <ctime>
+#include "signal_extractor_impl.h"
+
+namespace gr
+{
+  namespace phasma
+  {
+
+    signal_extractor::sptr
+    signal_extractor::make (float samp_rate, float total_bw,
+			    float channel_bw, size_t ifft_size,
+			    size_t silence_guardband, float signal_duration,
+			    float threshold_db, size_t sig_num)
+    {
+      return gnuradio::get_initial_sptr (
+	  new signal_extractor_impl (samp_rate, total_bw, channel_bw, ifft_size,
+				     silence_guardband, signal_duration,
+				     threshold_db, sig_num));
+    }
+
+    /*
+     * The private constructor
+     */
+    signal_extractor_impl::signal_extractor_impl (float samp_rate,
+						  float total_bw,
+						  float channel_bw,
+						  size_t ifft_size,
+						  size_t silence_guardband,
+						  float signal_duration,
+						  float threshold_db,
+						  size_t sig_num) :
+	    gr::sync_block ("signal_extractor",
+			    gr::io_signature::make2(2, 2, sizeof(float), sizeof(gr_complex)),
+			    gr::io_signature::make(0, 0, 0)),
+	    d_samp_rate (samp_rate),
+	    d_total_bw (total_bw),
+	    d_channel_bw (channel_bw),
+	    d_ifft_size (ifft_size),
+	    d_silence_guardband (silence_guardband),
+	    d_channel_num (d_total_bw / d_channel_bw),
+	    d_fft_size ((d_samp_rate * d_ifft_size) / d_channel_bw),
+	    d_signal_duration (signal_duration),
+	    d_snapshots_required(5),
+	    d_threshold_db (threshold_db),
+	    d_threshold_linear (std::pow (10, d_threshold_db / 10)),
+	    d_sig_num(sig_num),
+	    d_conseq_channel_num(150)
+    {
+      message_port_register_in (pmt::mp ("threshold"));
+      message_port_register_out (pmt::mp ("out"));
+
+      /* Process in a per-FFT basis */
+      set_output_multiple (d_fft_size);
+
+      d_ishift = (gr_complex*) volk_malloc (
+	  d_conseq_channel_num * d_ifft_size * sizeof(gr_complex), 32);
+
+      /* Calculation of Blackmann-Harris window */
+      for (size_t j = 0; j < d_conseq_channel_num; j++) {
+	d_blackmann_harris_win.push_back (
+	    (float*) volk_malloc ((j + 1) * d_fft_size * sizeof(float), 32));
+	for (size_t i = 0; i < d_ifft_size; i++) {
+	  d_blackmann_harris_win[j][i] = 0.35875
+	      - 0.48829 * cos ((2 * M_PI * i) / (d_fft_size - 1))
+	      + 0.14128 * cos ((4 * M_PI * i) / (d_fft_size - 1))
+	      - 0.01168 * cos ((6 * M_PI * i) / (d_fft_size - 1));
+	}
+      }
+
+      /* Allocate memory for possible useful IFFT plans*/
+      for (size_t i = 0; i < d_conseq_channel_num; i++) {
+	std::cout << i << std::endl;
+	d_ifft_plans.push_back (
+	    new fft::fft_complex ((i + 1) * d_ifft_size, false, 1));
+      }
+
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    signal_extractor_impl::~signal_extractor_impl ()
+    {
+      for (size_t i = 0; i < d_conseq_channel_num; i++) {
+	delete d_ifft_plans[i];
+	volk_free(d_blackmann_harris_win[i]);
+      }
+      volk_free (d_ishift);
+    }
+
+    int
+    signal_extractor_impl::work (int noutput_items,
+				 gr_vector_const_void_star &input_items,
+				 gr_vector_void_star &output_items)
+    {
+
+      /***C++11 Style:***/
+      std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+      const float *spectrum_mag = (const float *) input_items[0];
+      const gr_complex *fft_in = (const gr_complex *) input_items[1];
+
+      size_t available_snapshots = noutput_items / d_fft_size;
+
+      size_t sig_count = 0;
+      size_t silence_count = d_silence_guardband;
+      size_t sig_slot_checkpoint;
+      size_t sig_slot_curr;
+      size_t start_idx;
+      size_t end_idx;
+
+      pmt::pmt_t msg;
+
+      bool sig_alarm = false;
+
+      for (size_t s = 0; s < available_snapshots; s++) {
+	/**
+	 * TODO: Search spectrum for transmissions.
+	 * For each identified transmission apply an IFFT to get the time
+	 * domain samples and repeat until required snapshots are taken.
+	 * In favor of simplicity, only a fixed number of simultaneous
+	 * transmissions is handled.
+	 *
+	 * If this is the first snapshot of the timeslot try to identify
+	 * transmissions and lock on channels to observe. Transmissions that
+	 * span multiple channels should be treated as one.
+	 */
+
+	if (s == 0) {
+	  for (size_t i = 0; i < d_fft_size; i++) {
+	    sig_slot_curr = i / d_ifft_size;
+	    if (spectrum_mag[i] > d_threshold_linear) {
+	      silence_count = d_silence_guardband;
+	      /**
+	       * If there is silence and a peak is detected in the spectrum
+	       * raise a signal alarm and mark the current slot.
+	       */
+	      if (!sig_alarm) {
+		sig_alarm = true;
+		sig_slot_checkpoint = sig_slot_curr;
+	      }
+	      /**
+	       * Signal probably span in more channels, but have to split in
+	       * favor of simplicity.
+	       * Channels with multiple transmissions or mixings may occur,
+	       * but that's life.
+	       */
+	      else if (sig_slot_curr - sig_slot_checkpoint
+		  == d_conseq_channel_num - 1) {
+		std::time_t timestamp = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+		record_signal (fft_in, &d_signals, sig_slot_checkpoint, sig_slot_curr,
+			       std::ctime(&timestamp));
+		sig_slot_checkpoint = sig_slot_curr;
+		sig_alarm = false;
+		silence_count = d_silence_guardband;
+		sig_count++;
+	      }
+	    }
+	    else if ((spectrum_mag[i] < d_threshold_linear) && sig_alarm) {
+	      silence_count--;
+	      if ((!silence_count || i == d_fft_size - 1)
+		  && sig_count < d_sig_num) {
+		// Full -legal span- signal observed
+		sig_alarm = false;
+		silence_count = d_silence_guardband;
+		std::time_t timestamp = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+		record_signal (fft_in, &d_signals, sig_slot_checkpoint, sig_slot_curr,
+			       std::ctime(&timestamp));
+		sig_count++;
+	      }
+	    }
+	  }
+	}
+	/**
+	 * Else iterate through the identified channels and store the time
+	 * domain samples for each transmission.
+	 */
+	else {
+	  // TODO: What about timestamp when more than one snapshot available?
+//	  for (size_t i = 0; i < d_signals.size (); i++) {
+//	    	record_signal (fft_in, &d_signals, d_signals[i].start_slot_idx,
+//			   d_signals[i].end_slot_idx, std::ctime(&t));
+//	  	sig_count++;
+//	  }
+	}
+	msg = pmt::make_vector(sig_count, pmt::PMT_NIL);
+	for (size_t c=0; c < sig_count; c++) {
+	  pmt::vector_set(msg, c, d_msg_queue[c]);
+	}
+	message_port_pub (pmt::mp ("out"), msg);
+	d_signals.clear ();
+	d_signals.clear ();
+      }
+//      std::cout << "Time difference = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() <<std::endl;
+      return noutput_items;
+    }
+
+    void
+    signal_extractor_impl::record_signal (const gr_complex* fft_in,
+					  std::vector<phasma_signal_t>* signals,
+					  size_t sig_slot_checkpoint,
+					  size_t curr_slot, std::string timestamp)
+    {
+      // Insert record in the signal vector.
+      phasma_signal_t sig_rec;
+      sig_rec.start_slot_idx = sig_slot_checkpoint;
+      sig_rec.end_slot_idx = curr_slot;
+      size_t span = sig_rec.end_slot_idx - sig_rec.start_slot_idx;
+      size_t iq_size_bytes;
+
+      const gr_complex* sig_ptr = &fft_in[sig_rec.start_slot_idx*d_ifft_size];
+      /**
+       * Windowing and IFFT
+       */
+      volk_32fc_32f_multiply_32fc(&d_ifft_plans[span]->get_inbuf()[0], sig_ptr,
+      			d_blackmann_harris_win[span], d_ifft_size*span);
+      d_ifft_plans[span]->execute();
+      memcpy(&d_ishift[0],&d_ifft_plans[span]->get_outbuf()[(d_ifft_size*span) / 2],
+			      sizeof(gr_complex) * (d_ifft_size*span) / 2);
+      memcpy(&d_ishift[(d_ifft_size*span) / 2], &d_ifft_plans[span]->get_outbuf()[0],
+      			      sizeof(gr_complex) * (d_ifft_size*span) / 2);
+
+      if (curr_slot - sig_slot_checkpoint == 0) {
+	iq_size_bytes = d_ifft_size * d_snapshots_required * sizeof(gr_complex);
+	sig_rec.iq_samples = (gr_complex*) malloc(iq_size_bytes);
+      }
+      else {
+	iq_size_bytes = ((sig_rec.end_slot_idx - sig_rec.start_slot_idx) + 1) * d_ifft_size
+	      * d_snapshots_required * sizeof(gr_complex);
+	sig_rec.iq_samples = (gr_complex*) malloc(iq_size_bytes);
+      }
+      memcpy(sig_rec.iq_samples, d_ishift, sizeof(gr_complex) * (d_ifft_size*span));
+
+      d_signals.push_back (sig_rec);
+      PHASMA_DEBUG("--- SIGNAL RECORDED ---");
+      PHASMA_DEBUG("START: %d", d_signals.back().start_slot_idx);
+      PHASMA_DEBUG("END: %d", d_signals.back().end_slot_idx);
+
+      sigMF meta = sigMF("cf32",
+			 "./",
+			 "0.0.1",
+			 0,
+			 d_samp_rate,
+			 timestamp,
+			 sig_slot_checkpoint*d_ifft_size,
+			 (curr_slot-sig_slot_checkpoint)*d_ifft_size,
+			 sig_slot_checkpoint * d_channel_bw,
+			 curr_slot * d_channel_bw,
+			 "");
+
+      pmt::pmt_t tup = pmt::make_tuple(pmt::string_to_symbol(meta.toJSON()),
+				       pmt::make_blob(sig_rec.iq_samples, iq_size_bytes));
+      d_msg_queue.push_back(tup);
+
+      free(sig_rec.iq_samples);
+    }
+
+  } /* namespace phasma */
+} /* namespace gr */
+

--- a/lib/signal_extractor_impl.h
+++ b/lib/signal_extractor_impl.h
@@ -1,0 +1,96 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_PHASMA_SIGNAL_EXTRACTOR_IMPL_H
+#define INCLUDED_PHASMA_SIGNAL_EXTRACTOR_IMPL_H
+
+#include <phasma/signal_extractor.h>
+#include <gnuradio/fft/fft.h>
+#include <string>
+
+namespace gr
+{
+  namespace phasma
+  {
+
+    class signal_extractor_impl : public signal_extractor
+    {
+    private:
+
+      const float d_samp_rate;
+      const float d_total_bw;
+      const float d_channel_bw;
+
+      const size_t d_ifft_size;
+      const size_t d_silence_guardband;
+
+      size_t d_channel_num;
+      size_t d_fft_size;
+
+      const float d_signal_duration;
+      size_t d_snapshots_required;
+
+      const float d_threshold_db;
+      const float d_threshold_linear;
+      const size_t d_sig_num;
+      const size_t d_conseq_channel_num;
+
+      typedef struct
+      {
+	gr_complex* iq_samples;
+	size_t start_slot_idx;
+	size_t end_slot_idx;
+      } phasma_signal_t;
+
+      std::vector<phasma_signal_t> d_signals;
+
+      gr_complex* d_ishift;
+
+      std::vector<float*> d_blackmann_harris_win;
+      //float* d_blackmann_harris_win;
+
+      std::vector<fft::fft_complex*> d_ifft_plans;
+
+      std::vector<pmt::pmt_t> d_msg_queue;
+
+    public:
+      signal_extractor_impl (float samp_rate, float total_bw,
+			     float channel_bw, size_t ifft_size,
+			     size_t silence_guardband, float signal_duration,
+			     float threshold_db, size_t sig_num);
+
+      ~signal_extractor_impl ();
+
+      void
+      record_signal (const gr_complex* fft_in,
+		     std::vector<phasma_signal_t>* signals,
+		     size_t sig_slot_checkpoint,
+		     size_t curr_slot, std::string time);
+
+      int
+      work (int noutput_items, gr_vector_const_void_star &input_items,
+	    gr_vector_void_star &output_items);
+    };
+
+  } // namespace phasma
+} // namespace gr
+
+#endif /* INCLUDED_PHASMA_SIGNAL_EXTRACTOR_IMPL_H */
+

--- a/lib/utils/sigMF.cc
+++ b/lib/utils/sigMF.cc
@@ -1,0 +1,314 @@
+/*
+ * sigMF.cpp
+ *
+ *  Created on: Feb 24, 2017
+ *      Author: ctriant
+ */
+
+#include <phasma/utils/sigMF.h>
+#include <sstream>
+#include <json/json.h>
+
+sigMF::sigMF (std::string datatype, std::string datapath, std::string version,
+	      size_t capture_sample_start, size_t annotation_sample_start,
+	      size_t sample_count)
+{
+  d_datatype = datatype;
+  d_datapath = datapath;
+  d_version = version;
+  d_capture_sample_start = capture_sample_start;
+  d_annotation_samples_start = annotation_sample_start;
+  d_sample_count = sample_count;
+  d_freq_upper_edge = 0;
+  d_freq_lower_edge = 0;
+  d_offset = 0;
+  d_sample_rate = 0;
+  d_frequency = 0;
+}
+
+sigMF::sigMF (std::string datatype, std::string datapath, std::string version,
+	 size_t capture_sample_start, double sample_rate, std::string time,
+	 size_t annotation_sample_start, size_t sample_count, double freq_lower_edge,
+	 double freq_upper_edge, std::string comment)
+{
+  d_datatype = datatype;
+  d_datapath = datapath;
+  d_version = version;
+  d_capture_sample_start = capture_sample_start;
+  d_sample_rate = sample_rate;
+  d_time = time;
+  d_annotation_samples_start = annotation_sample_start;
+  d_sample_count = sample_count;
+  d_freq_upper_edge = freq_upper_edge;
+  d_freq_lower_edge = freq_lower_edge;
+  d_comment = comment;
+  d_offset = 0;
+  d_frequency = 0;
+}
+
+size_t
+sigMF::getAnnotationSamplesStart () const
+{
+  return d_annotation_samples_start;
+}
+
+void
+sigMF::setAnnotationSamplesStart (size_t annotationSamplesStart)
+{
+  d_annotation_samples_start = annotationSamplesStart;
+}
+
+const std::string&
+sigMF::getAuthor () const
+{
+  return d_author;
+}
+
+void
+sigMF::setAuthor (const std::string& author)
+{
+  d_author = author;
+}
+
+size_t
+sigMF::getCaptureSampleStart () const
+{
+  return d_capture_sample_start;
+}
+
+void
+sigMF::setCaptureSampleStart (size_t captureSampleStart)
+{
+  d_capture_sample_start = captureSampleStart;
+}
+
+const std::string&
+sigMF::getComment () const
+{
+  return d_comment;
+}
+
+void
+sigMF::setComment (const std::string& comment)
+{
+  d_comment = comment;
+}
+
+const std::string&
+sigMF::getDatapath () const
+{
+  return d_datapath;
+}
+
+void
+sigMF::setDatapath (const std::string& datapath)
+{
+  d_datapath = datapath;
+}
+
+const std::string&
+sigMF::getDatatype () const
+{
+  return d_datatype;
+}
+
+void
+sigMF::setDatatype (const std::string& datatype)
+{
+  d_datatype = datatype;
+}
+
+const std::string&
+sigMF::getDate () const
+{
+  return d_date;
+}
+
+void
+sigMF::setDate (const std::string& date)
+{
+  d_date = date;
+}
+
+const std::string&
+sigMF::getDescription () const
+{
+  return d_description;
+}
+
+void
+sigMF::setDescription (const std::string& description)
+{
+  d_description = description;
+}
+
+double
+sigMF::getFreqLowerEdge () const
+{
+  return d_freq_lower_edge;
+}
+
+void
+sigMF::setFreqLowerEdge (double freqLowerEdge)
+{
+  d_freq_lower_edge = freqLowerEdge;
+}
+
+double
+sigMF::getFreqUpperEdge () const
+{
+  return d_freq_upper_edge;
+}
+
+void
+sigMF::setFreqUpperEdge (double freqUpperEdge)
+{
+  d_freq_upper_edge = freqUpperEdge;
+}
+
+double
+sigMF::getFrequency () const
+{
+  return d_frequency;
+}
+
+void
+sigMF::setFrequency (double frequency)
+{
+  d_frequency = frequency;
+}
+
+const std::string&
+sigMF::getHw () const
+{
+  return d_hw;
+}
+
+void
+sigMF::setHw (const std::string& hw)
+{
+  d_hw = hw;
+}
+
+const std::string&
+sigMF::getLicense () const
+{
+  return d_license;
+}
+
+void
+sigMF::setLicense (const std::string& license)
+{
+  d_license = license;
+}
+
+uint64_t
+sigMF::getOffset () const
+{
+  return d_offset;
+}
+
+void
+sigMF::setOffset (uint64_t offset)
+{
+  d_offset = offset;
+}
+
+size_t
+sigMF::getSampleCount () const
+{
+  return d_sample_count;
+}
+
+void
+sigMF::setSampleCount (size_t sampleCount)
+{
+  d_sample_count = sampleCount;
+}
+
+double
+sigMF::getSampleRate () const
+{
+  return d_sample_rate;
+}
+
+void
+sigMF::setSampleRate (double sampleRate)
+{
+  d_sample_rate = sampleRate;
+}
+
+const std::string&
+sigMF::getSha512 () const
+{
+  return d_sha512;
+}
+
+void
+sigMF::setSha512 (const std::string& sha512)
+{
+  d_sha512 = sha512;
+}
+
+const std::string&
+sigMF::getTime () const
+{
+  return d_time;
+}
+
+void
+sigMF::setTime (const std::string& time)
+{
+  d_time = time;
+}
+
+const std::string&
+sigMF::getVersion () const
+{
+  return d_version;
+}
+
+void
+sigMF::setVersion (const std::string& version)
+{
+  d_version = version;
+}
+
+std::string
+sigMF::toJSON ()
+{
+  // TODO: Support all fields
+  Json::Value root;
+  Json::Value global;
+  Json::Value capture;
+  Json::Value capture_list(Json::arrayValue);
+  Json::Value annotation;
+
+  global["core:datapath"] = d_datapath;
+  global["core:datatype"] = d_datatype;
+
+  capture["core:sample_start"] = d_capture_sample_start;
+  capture["core:sample_rate"] = d_sample_rate;
+  capture["core:time"] = d_time;
+
+  capture_list.append(capture);
+
+  annotation["core:sample_start"] = d_annotation_samples_start;
+  annotation["core:sample_count"] = d_sample_count;
+  annotation["core:freq_lower_edge"] = d_freq_lower_edge;
+  annotation["core:freq_upper_edge"] = d_freq_upper_edge;
+  annotation["core:comment"] = d_comment;
+
+  root["annotation"] = annotation;
+  root["capture"] = capture_list;
+  root["global"] = global;
+
+  std::string json = root.toStyledString();
+
+  return json;
+}
+
+sigMF::~sigMF ()
+{
+}
+

--- a/swig/phasma_swig.i
+++ b/swig/phasma_swig.i
@@ -11,6 +11,7 @@
 #include "phasma/rforest_model.h"
 #include "phasma/eigenvalue_signal_detector.h"
 #include "phasma/opencv_predict.h"
+#include "phasma/signal_extractor.h"
 %}
 
 
@@ -20,3 +21,5 @@ GR_SWIG_BLOCK_MAGIC2(phasma, rforest_model);
 GR_SWIG_BLOCK_MAGIC2(phasma, eigenvalue_signal_detector);
 %include "phasma/opencv_predict.h"
 GR_SWIG_BLOCK_MAGIC2(phasma, opencv_predict);
+%include "phasma/signal_extractor.h"
+GR_SWIG_BLOCK_MAGIC2(phasma, signal_extractor);


### PR DESCRIPTION
This commit adds a new block for signal separation in an observed channel. The information of the separated transmission is encoded into a sigMF metafile alongside with the captured iq samples.
- Adds signal_separate block
- Introduces sigMF support