### PR TITLE
Refactor FFT operations on featureset generation

### DIFF
--- a/include/phasma/featuresets/jaga.h
+++ b/include/phasma/featuresets/jaga.h
@@ -22,7 +22,7 @@
 #define INCLUDED_PHASMA_JAGA_H
 
 #include <phasma/api.h>
-#include <fftw3.h>
+#include <gnuradio/fft/fft.h>
 
 #define JAGA_FEATURES_NUM 6
 
@@ -81,11 +81,8 @@ namespace gr
 
 	uint16_t* d_max;
 
-	float* d_fftw_in_buf;
-	fftwf_complex* d_fftw_out_buf;
-
 	// fft plan for channel measurements
-	fftwf_plan d_fft;
+	fft::fft_complex* d_fft;
 
 	size_t d_samples_num;
 	size_t d_features_num;

--- a/lib/rforest_model_c_impl.h
+++ b/lib/rforest_model_c_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /* 
- * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * Copyright 2017 Kostis Triantafyllakis - ctriant.
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,6 @@
 #include <phasma/featuresets/dummy_featureset.h>
 #include <phasma/featuresets/raw_iq_featureset.h>
 #include <phasma/featuresets/jaga.h>
-#include <gnuradio/fft/fft.h>
-#include <gnuradio/fft/window.h>
 #include <opencv2/ml.hpp>
 #include <opencv2/core.hpp>
 

--- a/lib/rforest_model_f_impl.h
+++ b/lib/rforest_model_f_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /* 
- * Copyright 2017 <+YOU OR YOUR COMPANY+>.
+ * Copyright 2017 Kostis Triantafyllakis - ctriant.
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,8 +24,7 @@
 #include <phasma/rforest_model_f.h>
 #include <phasma/featuresets/dummy_featureset.h>
 #include <phasma/featuresets/raw_iq_featureset.h>
-#include <gnuradio/fft/fft.h>
-#include <gnuradio/fft/window.h>
+#include <phasma/featuresets/jaga.h>
 #include <opencv2/ml.hpp>
 #include <opencv2/core.hpp>
 


### PR DESCRIPTION
This PR refactors the FFT operations on featureset generations.
Specifically, the gr-fft wrapper is used instead of direct fftw library.